### PR TITLE
Updated the README to replace npm start with npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Thank you for considering contributing to the **Euphoria-Web** project! Follow t
 6. **Run the Development Server** (Optional for Testing):
    - Start the development server to test your changes:
      ```bash
-     npm start
+     npm run dev
      ```
    - The application will be available at `http://localhost:3000`.
 


### PR DESCRIPTION
The current README specifies using npm start to start the development server, but the package.json uses the npm run dev command to launch Vite. 

This PR updates the README to correctly reflect the Vite setup and provides the proper command to start the development server.